### PR TITLE
Add Rényi entropy index

### DIFF
--- a/concentrationMetrics/model.py
+++ b/concentrationMetrics/model.py
@@ -294,6 +294,44 @@ class Index(object):
             else:
                 return h
 
+    def renyi(self, data, alpha):
+        """Calculate the Rényi Entropy of order alpha.
+
+        :param data: Positive numerical data
+        :type data: numpy array
+        :param alpha: Entropy order (alpha >= 0)
+        :type alpha: float
+        :return: Rényi Entropy (Float)
+
+        .. note:: At alpha=1 the Rényi entropy equals the Shannon entropy (limit evaluated explicitly).
+        .. note:: At alpha=2, H_2 = -log(HHI_unnormalized).
+
+        Formula: H_alpha = (1 / (1 - alpha)) * log(sum(p_i ^ alpha))
+
+        Reference: Rényi, A. (1961), "On measures of entropy and information",
+        *Proceedings of the 4th Berkeley Symposium on Mathematics, Statistics and Probability*,
+        Vol. 1, pp. 547--561.
+
+        `Open Risk Manual Entry for Rényi Entropy <https://www.openriskmanual.org/wiki/Renyi_Entropy>`_
+        """
+        weights = self.get_weights(data)
+        weights_nz = weights[weights != 0]
+        n = weights_nz.size
+        if n == 0:
+            return 0
+        else:
+            if alpha < 0:
+                raise ValueError('Alpha must be non-negative')
+            elif alpha == 0:
+                return np.log(float(n))
+            elif alpha == 1:
+                # limit as alpha -> 1 equals the Shannon entropy: -sum(p_i * log(p_i))
+                log_weights = np.log(weights_nz)
+                return -np.multiply(weights_nz, log_weights).sum()
+            else:
+                h = np.power(weights_nz, alpha).sum()
+                return np.log(h) / (1.0 - alpha)
+
     def atkinson(self, data, epsilon):
         """Calculate the Atkinson inequality index.
 

--- a/examples/python/renyi_example.py
+++ b/examples/python/renyi_example.py
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+# (c) 2016--2026 Open Risk (https://www.openriskmanagement.com), all rights reserved
+#
+# ConcentrationMetrics is licensed under the MIT license a copy of which is included
+# in the source distribution of concentrationMetrics. This is notwithstanding any licenses of
+# third-party software included in this distribution. You may not use this file except in
+# compliance with the License.
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Rényi Entropy example.
+
+Reference: Rényi, A. (1961), "On measures of entropy and information",
+Proceedings of the 4th Berkeley Symposium on Mathematics, Statistics and Probability,
+Vol. 1, pp. 547-561.
+
+Key properties illustrated:
+- For a uniform distribution of n elements, H_alpha = log(n) for all alpha >= 0.
+- At alpha=1, the Rényi entropy equals the Shannon entropy.
+- At alpha=2, H_2 = -log(HHI_unnormalized).
+- Higher alpha places more weight on the dominant share (lower entropy = more concentrated).
+"""
+
+import numpy as np
+
+import concentrationMetrics as cm
+
+myIndex = cm.Index()
+
+# --- Uniform distribution (4 equally-sized entities) ---
+print("Uniform distribution, n=4")
+vector_uniform = np.ones(4)
+for alpha in [0, 0.5, 1, 2, 3]:
+    print(f"  H_{alpha} = {myIndex.renyi(vector_uniform, alpha):.6f}  (log(4) = {np.log(4):.6f})")
+
+print()
+
+# --- Concentrated distribution (one dominant entity) ---
+print("Concentrated distribution: [10, 1, 1, 1, 1]")
+vector_skewed = np.array([10.0, 1.0, 1.0, 1.0, 1.0])
+for alpha in [0, 1, 2, 5]:
+    print(f"  H_{alpha} = {myIndex.renyi(vector_skewed, alpha):.6f}")
+
+print()
+
+# --- Relationship to HHI at alpha=2 ---
+print("Relationship H_2 = -log(HHI_unnormalized) for uniform n=4:")
+hhi_raw = myIndex.hhi(vector_uniform, normalized=False)
+print(f"  HHI (unnormalized) = {hhi_raw:.6f}")
+print(f"  -log(HHI)          = {-np.log(hhi_raw):.6f}")
+print(f"  H_2 (Rényi)        = {myIndex.renyi(vector_uniform, 2):.6f}")
+
+print()
+
+# --- Confidence interval for Rényi entropy at alpha=2 ---
+print("Bootstrap 95% CI for H_2 on a simulated portfolio (n=100):")
+portfolio = np.random.lognormal(mean=0, sigma=1, size=100)
+lower, value, upper = myIndex.compute(portfolio, 2, index='renyi', ci=0.95, samples=1000)
+print(f"  [{lower:.4f}, {value:.4f}, {upper:.4f}]")

--- a/tests/test.py
+++ b/tests/test.py
@@ -142,6 +142,28 @@ class TestConcentrationLib(unittest.TestCase):
         vector = np.random.normal(1000, 1, n)
         self.assertTrue(abs(1 - 1 / (n * myIndex.hti(vector)) - myIndex.gini(vector)) < ERROR_MARGIN)
 
+    def test_renyi(self):
+        """
+        Testing Rényi Entropy
+
+        For any uniform distribution of n elements, H_alpha = log(n) for all alpha >= 0.
+        At alpha=2, H_2 = -log(HHI_unnormalized) (verified independently).
+        Non-uniform check at alpha=2: data=[1,2,1], weights=[0.25,0.5,0.25],
+        H_2 = -log(0.25^2 + 0.5^2 + 0.25^2) = -log(0.375) ~ 0.9808292530.
+        """
+        myIndex = cm.Index()
+        n = 4
+        vector = np.ones(n)
+        # uniform distribution: H_alpha = log(n) for all alpha
+        self.assertTrue(abs(myIndex.renyi(vector, 0) - np.log(n)) < ERROR_MARGIN)
+        self.assertTrue(abs(myIndex.renyi(vector, 1) - np.log(n)) < ERROR_MARGIN)
+        self.assertTrue(abs(myIndex.renyi(vector, 2) - np.log(n)) < ERROR_MARGIN)
+        # at alpha=2: H_2 = -log(HHI_unnormalized)
+        self.assertTrue(abs(myIndex.renyi(vector, 2) + np.log(myIndex.hhi(vector, normalized=False))) < ERROR_MARGIN)
+        # non-uniform: data=[1,2,1], alpha=2, hand-computed H_2 = -log(0.375)
+        vector2 = np.array([1.0, 2.0, 1.0])
+        self.assertTrue(abs(myIndex.renyi(vector2, 2) - (-np.log(0.375))) < ERROR_MARGIN)
+
 
 class TestConfidenceIntervals(unittest.TestCase):
     """ Test confidence interval functionality
@@ -162,7 +184,7 @@ class TestConfidenceIntervals(unittest.TestCase):
 
         methods = [['cr', 5], ['berger_parker'], ['hhi'], ['hk', 3],
                    ['hoover'], ['gini'], ['shannon'], ['atkinson', 1.5], ['gei', 3],
-                   ['theil'], ['kolm', 2]]
+                   ['theil'], ['kolm', 2], ['renyi', 2]]
 
         print(self.shortDescription())
         for method in methods:


### PR DESCRIPTION
## Summary

Adds `renyi(data, alpha)` to the `Index` class, implementing the Rényi entropy of order α.

**Formula:**

```
H_α = (1 / (1 − α)) · log(Σ pᵢ^α)
```

**Special cases handled explicitly** (matching the existing pattern in `hk` and `gei`):
- α = 0 → `log(|support|)` (log of the number of non-zero entries)
- α = 1 → Shannon entropy (limit evaluated via the standard log formula; `hk` and `gei` use the same convention for their α = 1 cases)

**Source:** Rényi, A. (1961), "On measures of entropy and information", *Proc. 4th Berkeley Symposium on Mathematics, Statistics and Probability*, Vol. 1, pp. 547–561.

## Changes

- `concentrationMetrics/model.py`: new `renyi` method placed after `shannon`, following the parameterised-method pattern of `hk` and `gei`
- `tests/test.py`: new `test_renyi` in `TestConcentrationLib` with deterministic, hand-verifiable assertions:
  - uniform distribution → `H_α = log(n)` for α ∈ {0, 1, 2}
  - α = 2 cross-check: `H_2 = −log(HHI_unnormalized)`
  - non-uniform `[1, 2, 1]` at α = 2: `H_2 = −log(0.375) ≈ 0.9808`
  - `renyi` added to the bootstrap CI test, confirming scalar return and monotonic bounds
- `examples/python/renyi_example.py`: worked example illustrating the uniform-distribution property, concentration sensitivity, and the HHI relationship

## Test results

12 tests pass (11 pre-existing + `test_renyi`). The 3 `TestEllisonGlaeser` errors are pre-existing (`np.int` removed in NumPy 1.24+ and a list-indexing bug in `ellison_glaeser`) and are not affected by this PR.